### PR TITLE
port "regexpMustEmpty" property from prh

### DIFF
--- a/packages/@proofdict/types/README.md
+++ b/packages/@proofdict/types/README.md
@@ -16,6 +16,7 @@ export interface ProofdictRule {
     description?: string;
     expected: string;
     patterns: string[];
+    regexpMustEmpty: string;
     tags: string[];
     specs?: ProofdictRuleSpec[];
     [index: string]: any;

--- a/packages/@proofdict/types/src/index.ts
+++ b/packages/@proofdict/types/src/index.ts
@@ -16,6 +16,10 @@ export interface ProofdictRule {
      */
     patterns: string[];
     /**
+     * Ignored string from matches
+     */
+    regexpMustEmpty: string;
+    /**
      * Tags
      */
     tags: string[];


### PR DESCRIPTION
I need the "regexpMustEmpty" property in prh.

https://github.com/prh/prh/blob/master/misc/prh.yml#L74

This PR only update a type `ProofdictRule` to here your opinion about porting "regexpMustEmpty".
I think you intended to exclude `regexpMustEmpty` from proofdict, cause the type definition is too simple.

If you agree to port the property, merge this.
Then I will send another PR for `@proofdict/tester` to pass tests with rules have `regexpMustEmpty` 