### PR TITLE
fix(textlint-rule-proofdict): support browser field

### DIFF
--- a/packages/@proofdict/textlint-rule-proofdict/package.json
+++ b/packages/@proofdict/textlint-rule-proofdict/package.json
@@ -18,6 +18,9 @@
   ],
   "main": "lib/textlint-rule-proofdict.js",
   "types": "lib/textlint-rule-proofdict.d.ts",
+  "browser": {
+    "./lib/fetch-dctionary/node.js": "./lib/fetch-dctionary/browser.js"
+  },
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/browser.ts
+++ b/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/browser.ts
@@ -1,0 +1,10 @@
+import type { RuleOption } from "../RuleOptions";
+import type { Proofdict } from "@proofdict/tester";
+import { MODE } from "../mode";
+
+export default (_options: RuleOption, mode: MODE): Proofdict | undefined => {
+    if (mode === MODE.LOCAL) {
+        throw new Error("Local mode does not work on browser");
+    }
+    return;
+};

--- a/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/index.ts
+++ b/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/index.ts
@@ -1,9 +1,8 @@
 import { RuleOption } from "../RuleOptions";
 import { MODE } from "../mode";
 import { openStorage } from "../dictionary-storage";
-import * as globby from "globby";
-import yaml from "js-yaml";
-import { Proofdict, ProofdictRule } from "@proofdict/tester";
+import { Proofdict } from "@proofdict/tester";
+import loadFromLocal from "./node";
 
 /**
  * @param options
@@ -26,13 +25,11 @@ export const getDictionary = async (options: RuleOption, mode: MODE): Promise<Pr
         }
     }
     // LOCAL
-    if (mode === MODE.LOCAL && options.dictGlob) {
-        try {
-            const files = globby.sync(options.dictGlob);
-            proofDictData = files.map((filePath) => {
-                return yaml.safeLoad(filePath) as ProofdictRule;
-            });
-        } catch (error) {}
+    if (mode === MODE.LOCAL) {
+        // This module will be replaced with noop in browser
+        // package.json "browser" field define it
+        // https://github.com/defunctzombie/package-browser-field-spec
+        return loadFromLocal(options, mode);
     }
     return proofDictData;
 };

--- a/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/node.ts
+++ b/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/node.ts
@@ -1,0 +1,24 @@
+import * as globby from "globby";
+import yaml from "js-yaml";
+import { ProofdictRule } from "@proofdict/types";
+import { RuleOption } from "../RuleOptions";
+import { Proofdict } from "@proofdict/tester";
+import { MODE } from "../mode";
+
+export default (options: RuleOption, mode: MODE): Proofdict | undefined => {
+    if (mode !== MODE.LOCAL) {
+        return;
+    }
+    if (!options.dictGlob) {
+        return;
+    }
+    try {
+        const files = globby.sync(options.dictGlob);
+        return files.map((filePath) => {
+            return yaml.safeLoad(filePath) as ProofdictRule;
+        });
+    } catch (error) {
+        console.error(error);
+    }
+    return;
+};


### PR DESCRIPTION
Pass

```
$ npx can-bundle-it  @proofdict/textlint-rule-proofdict --verbose --no-fs
```