### PR TITLE
fix(textlint-rule-proofdict): fixed to be able to read the dictionary specified in dictGlob

### DIFF
--- a/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/node.ts
+++ b/packages/@proofdict/textlint-rule-proofdict/src/fetch-dictionary/node.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import * as globby from "globby";
 import yaml from "js-yaml";
 import { ProofdictRule } from "@proofdict/types";
@@ -15,7 +16,7 @@ export default (options: RuleOption, mode: MODE): Proofdict | undefined => {
     try {
         const files = globby.sync(options.dictGlob);
         return files.map((filePath) => {
-            return yaml.safeLoad(filePath) as ProofdictRule;
+            return yaml.safeLoad(fs.readFileSync(filePath, "utf8")) as ProofdictRule;
         });
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
This issue was caused by passing the file path defined dictGlob to yaml loader `js-yaml.safeLoad()` (This loader need to pass the string in yaml files). So, I changed to pass `fs.readFileSync(filePath, "utf8")` from filePath.

Fix #63 